### PR TITLE
Make some changes to example Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,15 +4,14 @@ lane :test do |options|
   scan_options = {
     scheme: scheme_to_test,
     device: 'iPhone 5s (10.0)',
-    output_directory: 'artifacts/tests',
-    custom_report_file_name: 'report.xml'
+    output_directory: 'artifacts/tests'
   }
   begin
     retry_count ||= 0
     scan(scan_options)
   rescue => e
     UI.important("failure noted: #{e}")
-    report_filepath = File.absolute_path('../artifacts/tests/report.xml')
+    report_filepath = File.absolute_path('../artifacts/tests/report.junit')
     unless File.exist?(report_filepath)
       raise e
     end
@@ -25,6 +24,8 @@ lane :test do |options|
       clear_derived_data
       reset_simulator_contents if retry_count > 1
       retry
+    else
+      exit 1
     end
   end
 end


### PR DESCRIPTION
This PR makes some tweaks to the example Fastfile to account for changes to Fastlane. The `custom_report_file_name` option is deprecated in `scan` and doesn't function anymore, since there are actually three report types now. I changed the `report_filepath` to reference `report.junit`, which is the name that Fastlane uses for the JUnit XML report now. In addition I added an else statement which exits with a non-zero exit code if all three retries fail. This is to ensure on CI that the build gets marked as failed if all tests don't end up passing.